### PR TITLE
Feat: convert issue templates to forms and add labeler workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -53,17 +53,61 @@ body:
       1. See error
   validations:
     required: false
-- type: textarea
-  id: environment-info
+- type: dropdown
+  id: operating-system
   attributes:
-    label: Environment & Version Info
-    description: Please fill out each field on the table, adding a new row for each Stormlight module this report applies to by copy-pasting the system row.
+    label: Operating System
+    description: "Which operating system are you using? *Note: if yours isn't listed, select 'Other' and provide details at the bottom of the form.*"
+    multiple: false
+    default: 0
+    options:
+      - Windows 10
+      - Windows 11
+      - MacOS
+      - Ubuntu
+      - Debian
+      - Other
+  validations:
+    required: true
+- type: dropdown
+  id: web-browser
+  attributes:
+    label: Web Browser(s)
+    description: "Which web browser(s) are you using to connect to foundry? *Note: if yours isn't listed, select 'Other' and provide details at the bottom of the form."
+    multiple: true
+    default: 0
+    options:
+      - Foundry Executable
+      - Chrome
+      - Firefox
+      - Safari
+      - Opera
+      - Edge
+      - Other
+  validations:
+    required: true
+- type: dropdown
+  id: host-method
+  attributes:
+    label: Hosting Method
+    description: "How are you hosting the foundry instance?"
+    multiple: false
+    default: 0
+    options:
+      - Localhost/same PC
+      - Dedicated server/vps
+      - The Forge
+      - Other
+  validations:
+    required: true
+- type: textarea
+  id: version-info
+  attributes:
+    label: Version Info
+    description: Please fill out the version field on the table, adding a new row for each Stormlight module this report applies to by copy-pasting the system row and filling in the info for each.
     value: |
       |**Name**|**Version**|
       |---|---|
-      |**OS**|_ex. Windows 10, Ubuntu 20.04, etc_|
-      |**Browser**|_Chrome, Firefox, etc_|
-      |**Foundry**|_ex. 13.346_|
       |**System**|_ex. 2.0.4_|
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug Report
+description: Please use this form to report any bugs you encounter as they pertain to the premium Stormlight modules.
+labels: type | bug
+body:
+- type: checkboxes
+  id: existing-issue
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues to ensure this bug has not already been reported
+      required: true
+- type: dropdown
+  id: modules-list
+  attributes:
+    label: Relevant Module(s)
+    description: "Which Stormlight modules are relevant to this bug report? (Note: you may select more than one)"
+    multiple: true
+    default: 2
+    options:
+      - All
+      - Advanced Adversaries
+      - Handbook
+      - Speak the Words
+      - Stonewalkers
+      - Stormlight Scenarios
+      - World Guide
+  validations:
+    required: true
+- type: textarea
+  id: bug-description
+  attributes:
+    label: Describe the bug
+    description: A clear and concise description of what the bug is.
+  validations:
+    required: true
+- type: textarea
+  id: expected-behavior
+  attributes:
+    label: Expected Behavior
+    description: A clear and concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  id: reproduction-steps
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. Go to '...'
+      1. Click on '...'
+      1. Scroll down to '...'
+      1. See error
+  validations:
+    required: false
+- type: textarea
+  id: environment-info
+  attributes:
+    label: Environment & Version Info
+    description: Please fill out each field on the table, adding a new row for each Stormlight module this report applies to by copy-pasting the system row.
+    value: |
+      |**Name**|**Version**|
+      |---|---|
+      |**OS**|_ex. Windows 10, Ubuntu 20.04, etc_|
+      |**Browser**|_Chrome, Firefox, etc_|
+      |**Foundry**|_ex. 13.346_|
+      |**System**|_ex. 2.0.4_|
+  validations:
+    required: false
+- type: textarea
+  id: extra-context
+  attributes:
+    label: Screenshots and Additional Context
+    description: |
+      Add screenshots and any other context about the problem here. Logs, list of loaded modules, etc.
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/2-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.yml
@@ -1,0 +1,60 @@
+name: Feature Request
+description: Please use this form to request new features that pertain to the premium Stormlight modules.
+labels: type | feature request
+body:
+- type: checkboxes
+  id: existing-issue
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the feature you're requesting.
+    options:
+    - label: I have searched the existing issues to ensure this feature has not already been requested
+      required: true
+- type: dropdown
+  id: modules-list
+  attributes:
+    label: Relevant Module(s)
+    description: "Which Stormlight modules are relevant to this feature request? (Note: you may select more than one)"
+    multiple: true
+    default: 0
+    options:
+      - All
+      - Advanced Adversaries
+      - Handbook
+      - Speak the Words
+      - Stonewalkers
+      - Stormlight Scenarios
+      - World Guide
+  validations:
+    required: true
+- type: textarea
+  id: feature-reason
+  attributes:
+    label: Is your feature request related to a problem? Please describe.
+    description: "A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]"
+  validations:
+    required: true
+- type: textarea
+  id: feature-description
+  attributes:
+    label: Describe the solution you'd like.
+    description: "A clear and concise description of what you want to happen."
+  validations:
+    required: true
+- type: textarea
+  id: feature-alternatives
+  attributes:
+    label: Describe alternatives you've considered
+    description: A clear and concise description of any alternative solutions or features you've considered.
+  validations:
+    required: false
+- type: textarea
+  id: extra-context
+  attributes:
+    label: Screenshots and Additional Context
+    description: |
+      Add screenshots and any other context about the request here. Links to third party modules, specific APIs, etc.
+
+      Tip: You can attach images or other files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/3-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/3-enhancement.yml
@@ -1,0 +1,53 @@
+name: Enhancement
+description: A task that enhances module workflows in some way
+labels: type | enhancement
+body:
+- type: checkboxes
+  id: existing-issue
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the enhancement you're requesting.
+    options:
+    - label: I have searched the existing issues to ensure this enhancement has not already been requested
+      required: true
+- type: dropdown
+  id: modules-list
+  attributes:
+    label: Relevant Module(s)
+    description: "Which Stormlight modules are relevant to this task? (Note: you may select more than one)"
+    multiple: true
+    default: 0
+    options:
+      - All
+      - Advanced Adversaries
+      - Handbook
+      - Speak the Words
+      - Stonewalkers
+      - Stormlight Scenarios
+      - World Guide
+  validations:
+    required: true
+- type: textarea
+  id: task-reason
+  attributes:
+    label: What needs changing?
+    description: "A clear and concise description of what the task is. Ex. We need to support latest Node LTS / Foundry v##, It would be nice if [...]"
+  validations:
+    required: true
+- type: textarea
+  id: task-alternatives
+  attributes:
+    label: Describe alternatives you've considered
+    description: A clear and concise description of any alternative solutions or features you've considered.
+  validations:
+    required: false
+- type: textarea
+  id: extra-context
+  attributes:
+    label: Screenshots and Additional Context
+    description: |
+      Add screenshots and any other context about the request here. Links to third party modules, specific APIs, etc.
+
+      Tip: You can attach images or other files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/4-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/4-documentation.yml
@@ -1,0 +1,46 @@
+name: Documentation
+description: A task that provides extra documentation for user-facing module content
+labels: type | documentation
+body:
+- type: checkboxes
+  id: existing-issue
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the documentation you're requesting.
+    options:
+    - label: I have searched the existing issues to ensure this documentation has not yet been requested
+      required: true
+- type: dropdown
+  id: modules-list
+  attributes:
+    label: Relevant Module(s)
+    description: "Which Stormlight modules are relevant to this task? (Note: you may select more than one)"
+    multiple: true
+    default: 0
+    options:
+      - All
+      - Advanced Adversaries
+      - Handbook
+      - Speak the Words
+      - Stonewalkers
+      - Stormlight Scenarios
+      - World Guide
+  validations:
+    required: true
+- type: textarea
+  id: task-reason
+  attributes:
+    label: What needs changing?
+    description: "A clear and concise description of what the task is. Ex. We need to provide [info] on [module feature], We should update [module] documentation, It would be nice if [...]"
+  validations:
+    required: true
+- type: textarea
+  id: extra-context
+  attributes:
+    label: Screenshots and Additional Context
+    description: |
+      Add screenshots and any other context about the request here. Links to third party modules, specific APIs, etc.
+
+      Tip: You can attach images or other files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Metalworks Discord
+    url: https://discord.gg/GwGTMknXhp
+    about: If you want direct communication and faster answers, please join our discord!

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+# Add source | advanced adversaries label if all or advanced adversaries is selected in issue template
+source | advanced adversaries:
+  - '/(?<=### Relevant Module\(s\)[\n\r]*^.*)(All|Advanced Adversaries)[^\n\r]*$/gmi'
+
+# Add source | handbook label if all or handbook is selected in issue template
+source | handbook:
+  - '/(?<=### Relevant Module\(s\)[\n\r]*^.*)(All|Handbook)[^\n\r]*$/gmi'
+
+# Add source | speak the words label if all or speak the words is selected in issue template
+source | speak the words:
+  - '/(?<=### Relevant Module\(s\)[\n\r]*^.*)(All|Speak the Words)[^\n\r]*$/gmi'
+
+# Add source | stonewalkers label if all or stonewalkers is selected in issue template
+source | stonewalkers:
+  - '/(?<=### Relevant Module\(s\)[\n\r]*^.*)(All|Stonewalkers)[^\n\r]*$/gmi'
+
+# Add source | stormlight scenarios label if all or stormlight scenarios is selected in issue template
+source | stormlight scenarios:
+  - '/(?<=### Relevant Module\(s\)[\n\r]*^.*)(All|Stormlight Scenarios)[^\n\r]*$/gmi'
+
+# Add source | worldguide label if all or worldguide is selected in issue template
+source | worldguide:
+  - '/(?<=### Relevant Module\(s\)[\n\r]*^.*)(All|World Guide)[^\n\r]*$/gmi'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v3.4
+      with:
+        configuration-path: .github/labeler.yml
+        not-before: 2026-02-01T00:00:00Z
+        enable-versioned-regex: 0
+        repo-token: ${{ github.token }}


### PR DESCRIPTION
This creates proper forms that can be filled out, with enforced fields. It also automatically labels based on selected module(s), and enforces a no-blank-template policy. Also includes a link below issue templates to the Metalworks discord.

Note: labeler also has a minimum date set to prevent it attempting to modify the labels of issues created prior to this template, which can be modified before merging to match current date at that time